### PR TITLE
golangci-lint導入（errcheck+govet+staticcheck）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,5 +14,7 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: "1.25.0"
+      - name: Install golangci-lint
+        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.5.0
       - run: make build
       - run: make quality

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,34 @@
+version: "2"
+
+linters:
+  default: none
+  enable:
+    - errcheck
+    - govet
+    - staticcheck
+  settings:
+    errcheck:
+      exclude-functions:
+        - fmt.Fprint
+        - fmt.Fprintf
+        - fmt.Fprintln
+        - (io.Writer).Write
+        - (*bufio.Writer).Flush
+        - (*bufio.Writer).Write
+        - (*os.File).Close
+        - (*os.File).Seek
+        - (encoding/json.Encoder).Encode
+        - (*bytes.Buffer).ReadFrom
+        - (*bytes.Buffer).WriteTo
+    staticcheck:
+      checks:
+        - all
+        - "-QF1001"
+        - "-QF1003"
+        - "-QF1011"
+        - "-ST1023"
+  exclusions:
+    rules:
+      - path: _test\.go
+        linters:
+          - errcheck

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test quality
+.PHONY: build test lint fmt quality
 
 # 全ツールのディレクトリを自動検出
 TOOLS := $(wildcard cmd/gf-*)
@@ -15,9 +15,16 @@ test:
 		(cd $$tool && go test -v ./...); \
 	done
 
-quality: test
+lint:
 	@for tool in $(TOOLS); do \
-		echo "Vetting $$tool..."; \
-		(cd $$tool && go vet ./...); \
+		echo "Linting $$tool..."; \
+		(cd $$tool && golangci-lint run --config ../../.golangci.yml ./...); \
 	done
+
+fmt:
+	@for tool in $(TOOLS); do \
+		(cd $$tool && gofmt -l .); \
+	done
+
+quality: test lint
 	@echo "All quality checks passed."

--- a/cmd/gf-grep/main.go
+++ b/cmd/gf-grep/main.go
@@ -136,7 +136,7 @@ func expandRecursive(paths []string) ([]string, []error) {
 			files = append(files, p)
 			continue
 		}
-		filepath.Walk(p, func(path string, fi os.FileInfo, err error) error {
+		err = filepath.Walk(p, func(path string, fi os.FileInfo, err error) error {
 			if err != nil {
 				errs = append(errs, err)
 				return nil
@@ -146,6 +146,9 @@ func expandRecursive(paths []string) ([]string, []error) {
 			}
 			return nil
 		})
+		if err != nil {
+			errs = append(errs, err)
+		}
 	}
 	return files, errs
 }

--- a/cmd/gf-wc/main.go
+++ b/cmd/gf-wc/main.go
@@ -163,7 +163,7 @@ func printJSON(c counts, name string) {
 	}
 	enc := json.NewEncoder(os.Stdout)
 	enc.SetIndent("", "  ")
-	enc.Encode(jc)
+	_ = enc.Encode(jc)
 }
 
 func printJSONMulti(results []fileResult, total counts) {
@@ -190,7 +190,7 @@ func printJSONMulti(results []fileResult, total counts) {
 	}
 	enc := json.NewEncoder(os.Stdout)
 	enc.SetIndent("", "  ")
-	enc.Encode(out)
+	_ = enc.Encode(out)
 }
 
 func printCounts(c counts, name string, showAll, showLines, showWords, showBytes, showChars bool) {


### PR DESCRIPTION
## Summary
- golangci-lint v2.5.0 を導入し、`errcheck` / `govet` / `staticcheck` による静的解析をCI・ローカル両方で実行可能に
- `gf-grep`・`gf-wc` で検出されたlintエラー（戻り値未チェック）を修正
- Makefileに `lint` / `fmt` ターゲットを追加し、`make quality` に統合

## Test plan
- [x] `make quality` が全ツールでPASS（テスト + lint）
- [ ] CI（GitHub Actions）でのlint実行確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)